### PR TITLE
added image source for central america

### DIFF
--- a/MMM-Globe.css
+++ b/MMM-Globe.css
@@ -2,3 +2,7 @@
 	-webkit-clip-path: circle(50% at 50% 50%);
 	clip-path: circle(50% at 50% 50%);
 }
+.MMM-Globe-image-centralAmericaDiscNat {
+	-webkit-clip-path: circle(44% at 50% 50%);
+	clip-path: circle(44% at 50% 50%);
+}

--- a/MMM-Globe.js
+++ b/MMM-Globe.js
@@ -25,7 +25,9 @@ Module.register("MMM-Globe", {
 			'airMass': 'http://rammb.cira.colostate.edu/ramsdis/online/images/latest/himawari-8/full_disk_ahi_rgb_airmass.jpg',
 			'fullBand': 'http://rammb.cira.colostate.edu/ramsdis/online/images/latest/himawari-8/himawari-8_band_03_sector_02.gif',
 			'europeDiscNat': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBNatColour_LowResolution.jpg',
-			'europeDiscSnow': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBSolarDay_CentralEurope.jpg'
+			'europeDiscSnow': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBSolarDay_CentralEurope.jpg',
+			'centralAmericaDiscNat': 'http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_med/latestfull.jpg'
+
 		}
 		this.hiResImageUrls = {
 			'natColor': 'http://rammb.cira.colostate.edu/ramsdis/online/images/latest_hi_res/himawari-8/full_disk_ahi_natural_color.jpg',
@@ -33,7 +35,8 @@ Module.register("MMM-Globe", {
 			'airMass': 'http://rammb.cira.colostate.edu/ramsdis/online/images/latest_hi_res/himawari-8/full_disk_ahi_rgb_airmass.jpg',
 			'fullBand': 'http://rammb.cira.colostate.edu/ramsdis/online/images/latest/himawari-8/himawari-8_band_03_sector_02.gif',
 			'europeDiscNat': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBNatColour_LowResolution.jpg',
-			'europePartSnow': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBSolarDay_CentralEurope.jpg'
+			'europePartSnow': 'http://oiswww.eumetsat.org/IPPS/html/latestImages/EUMETSAT_MSG_RGBSolarDay_CentralEurope.jpg',
+			'centralAmericaDiscNat': 'http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg'
 		}
 		console.log(this.imageUrls[this.config.style]);
 		if (this.config.ownImagePath != '') {
@@ -56,17 +59,21 @@ Module.register("MMM-Globe", {
 	},
 
 	// Override dom generator.
+
 	getDom: function () {
 		var wrapper = document.createElement("div");
 		if (this.config.style == "europeDiscNat") {
-			//wrapper.style.height = "587px";
 			wrapper.style.height = 0.98 * this.config.imageSize - 1 + "px";
 			wrapper.style.overflow = "hidden";
 		}
 
+
 		var image = document.createElement("img");
 		if (this.config.ownImagePath != '') {
 			image.src = this.url;
+		} else if (this.config.style == "centralAmericaDiscNat"){
+			image.src = this.url + '?' + new Date().getTime();
+			image.className = 'MMM-Globe-image-centralAmericaDiscNat';
 		} else {
 			image.src = this.url + '?' + new Date().getTime();
 			image.className = 'MMM-Globe-image';

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ The entry in `config.js` can include the following options:
 
 |Option|Description|
 |---|---|
-|`style`|Style of the image. There are four diffrent styles available. You can preview them: <br>
-[asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp) <br>
-[africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) <br>
-[latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)
+|`style`|Style of the image. There are four diffrent styles available. You can preview them [asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp), [africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) , [latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)
 <br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat` |
 |`imageSize`|Defines the size of the displayed image in pixels. <br><br>**Type:** `integer`<br>**Default value:** `600`|
 |`updateInterval`|How often the image is updated. There is a new picture uploadet every 10 minutes. So there is no need to go faster.<br><br>**Default value:** `10 • 60 • 1000 // every 10 minutes`|

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ The entry in `config.js` can include the following options:
 
 |Option|Description|
 |---|---|
-|`style`|Style of the image. There are four diffrent styles available. You can preview them [here for the asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp) or [here for for the africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html).<br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`|
+|`style`|Style of the image. There are four diffrent styles available. You can preview them: <br>
+[asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp) <br>
+[africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) <br>
+[latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)
+<br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat` |
 |`imageSize`|Defines the size of the displayed image in pixels. <br><br>**Type:** `integer`<br>**Default value:** `600`|
 |`updateInterval`|How often the image is updated. There is a new picture uploadet every 10 minutes. So there is no need to go faster.<br><br>**Default value:** `10 • 60 • 1000 // every 10 minutes`|
 |`ownImagePath`|If you want to display a custom picture, place the link of it here. The module will automatically display it.<br><br>**Default value:** `''`|

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ The entry in `config.js` can include the following options:
 
 |Option|Description|
 |---|---|
-|`style`|Style of the image. There are four diffrent styles available. You can preview them [asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp), [africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) , [latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)
-<br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat` |
+|`style`|Style of the image. There are four diffrent styles available. You can preview them [here for the asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp) or [here for for the africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) or [here for latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)<br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat`|
 |`imageSize`|Defines the size of the displayed image in pixels. <br><br>**Type:** `integer`<br>**Default value:** `600`|
 |`updateInterval`|How often the image is updated. There is a new picture uploadet every 10 minutes. So there is no need to go faster.<br><br>**Default value:** `10 • 60 • 1000 // every 10 minutes`|
 |`ownImagePath`|If you want to display a custom picture, place the link of it here. The module will automatically display it.<br><br>**Default value:** `''`|


### PR DESCRIPTION
- added source from http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/ with med and high resolution
- added css-style to for central american image to "cut the globe" from the original image
- added preview and source option in README.md