### PR TITLE
Updated display of the map preview links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The entry in `config.js` can include the following options:
 
 |Option|Description|
 |---|---|
-|`style`|Style of the image. There are four diffrent styles available. You can preview them [here for the asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp) or [here for for the africa/europe-centric images] (http://oiswww.eumetsat.org/IPPS/html/latestImages.html) or [here for latin america-centric images] (http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)<br><br>**Type:** `string`<br>**Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat`|
+|`style`|Style of the image. There are four different styles available depending on your desired center. Preview them here:<br>* [Asia-centric images](http://rammb.cira.colostate.edu/ramsdis/online/himawari-8.asp)<br>* [Africa/Europe-centric images](http://oiswww.eumetsat.org/IPPS/html/latestImages.html)<br>* [Latin America-centric images](http://goes.gsfc.nasa.gov/goescolor/goeseast/overview2/color_lrg/latestfull.jpg)<br><br>**Type:** `string` **Possible values:** `natColor`, `geoColor`, `airMass`, `fullBand`, `europeDiscNat`, `europeDiscSnow`, `centralAmericaDiscNat`|
 |`imageSize`|Defines the size of the displayed image in pixels. <br><br>**Type:** `integer`<br>**Default value:** `600`|
 |`updateInterval`|How often the image is updated. There is a new picture uploadet every 10 minutes. So there is no need to go faster.<br><br>**Default value:** `10 • 60 • 1000 // every 10 minutes`|
 |`ownImagePath`|If you want to display a custom picture, place the link of it here. The module will automatically display it.<br><br>**Default value:** `''`|


### PR DESCRIPTION
The original link displays were broken, so modified to correct them and put them into a list. 
Note: There are only 3 links, though the text states that there are four options.